### PR TITLE
Update README.md to work better with Github-flavored markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ For development you should install ckanext-dgu-local as follows.
 
 1. Install this extension as normal using pip in your activated environment:
 
-    (pyenv) $ pip install -e "git+https://github.com/datagovuk/ckanext-dgu-local.git#egg=ckanext-dgu-local"
+    `(pyenv) $ pip install -e "git+https://github.com/datagovuk/ckanext-dgu-local.git#egg=ckanext-dgu-local"`
 
 2. Activate the plugins by adding them to the CKAN config and then restarting CKAN:
 
-    ckan.plugins = ...other_plugins... dgu_local lga_harvester
+    `ckan.plugins = ...other_plugins... dgu_local lga_harvester`
 
 3. Setup the database tables:
 
-    paster --plugin=ckanext-dgu-local dgulocal init --config=ckan_default.ini
+    `paster --plugin=ckanext-dgu-local dgulocal init --config=ckan_default.ini`
 
 
 ## Plugins
@@ -39,11 +39,11 @@ For development you should install ckanext-dgu-local as follows.
 
 The tests for ckanext-dgu-local can be run from the ckanext-dgu-local folder using:
 
-    nosetests --ckan --with-pylons=test-core.ini ckanext/dgulocal/tests
+    `nosetests --ckan --with-pylons=test-core.ini ckanext/dgulocal/tests`
 
 And some tests do not use the database so can be run in sqlite:
 
-    nosetests --ckan --with-pylons=test.ini ckanext/dgulocal/tests/test_harvester.py
+    `nosetests --ckan --with-pylons=test.ini ckanext/dgulocal/tests/test_harvester.py`
 
 
 ## Metadata
@@ -52,18 +52,21 @@ This extension relies on PackageExtras being added to packages that are created,
 
 ### Package Extras
 
+```
 |Key|Value|
 |--|--|
 |lga_identifier|The publisher-wide unique identifier for this dataset|
 |lga_services|A JSON list of service URL/Label pairs|
 |lga_functions|A JSON list of function URL/Label pairs|
+```
 
 ### Group (publisher) Extras
 
+```
 |Key|Value|
 |--|--|
 |geo_boundary|The GEOJson describing the polygon within which this authority lives - not used in this release|
-
+```
 
 ## Licence
 


### PR DESCRIPTION
Very tiny change, just adds backticks around indented code blocks inside the numbered list, and around the tables. This way the readme displays correctly in all markdown processors :)
